### PR TITLE
Clarify script name fallback

### DIFF
--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -29,15 +29,17 @@
 #'
 #' @export
 getScriptName <- function() {
-  # Check if rstudioapi is available
+  scriptName <- ""
+  # Initialize scriptName and check if rstudioapi is available to safely attempt retrieval
+  # of the active script name in RStudio.
   if (!requireNamespace("rstudioapi", quietly = TRUE)) {
     message("rstudioapi package is not available. Please install it using install.packages('rstudioapi').")
   } else {
     scriptName <- basename(rstudioapi::getSourceEditorContext()$path)
   }
-  # If scriptName is empty, return basename of OutDir
-  # Can happen at an unsaved file, etc.
-  if (scriptName == "") scriptName <- basename(OutDir)
+  # If scriptName is still empty (e.g., unsaved file or rstudioapi unavailable), fall back
+  # to the basename of the current working directory with basename(getwd()).
+  if (scriptName == "") scriptName <- basename(getwd())
 
   return(scriptName)
 }


### PR DESCRIPTION
## Summary
- Clarify behavior of `getScriptName()` by initializing `scriptName` and documenting `rstudioapi` check
- Use `basename(getwd())` as a fallback when script name isn't available

## Testing
- `R CMD build .`
- `R CMD check CodeAndRoll2_2.7.0.tar.gz` *(fails: Packages required but not available: 'Stringendo', 'colorRamps', 'dplyr', 'gplots', 'gtools', 'plyr', 'purrr', 'RColorBrewer', 'rstudioapi', 'sessioninfo', 'stringr', 'tibble')*


------
https://chatgpt.com/codex/tasks/task_e_68920ca1a274832cb7eb9f84a3c013f6