### PR TITLE
fix: remove undefined helpers

### DIFF
--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -87,14 +87,20 @@ savehistory_2 <- function() {
   script_name <- try(basename(rstudioapi::getSourceEditorContext()$path), silent = TRUE)
   if (inherits(script_name, "try-error")) script_name <- ""
 
-  file_name <- ppp(
+  # Build file name while skipping empty components
+  parts <- c(
     "command_history",
     format(Sys.time(), format = "%Y.%m.%d"),
-    script_name, "txt"
+    script_name
   )
+  parts <- parts[parts != ""]
+  file_name <- paste0(paste(parts, collapse = "."), ".txt")
 
-  # Save the command history
-  savehistory(file = file_name)
+  # Save the command history if possible
+  tryCatch(
+    savehistory(file = file_name),
+    error = function(e) warning("Could not save command history: ", e$message)
+  )
 
   # Print and return the file path
   print(file.path(current_dir, file_name))
@@ -195,8 +201,11 @@ list.fromNames <- function(x = LETTERS[1:5], fill = NaN, use.names = FALSE) {
     } else {
       x
     }
-
-  kollapse("List of", length(liszt), "| names:", head(names(liszt)), "...", collapseby = " ")
+  message(
+    "List of ", length(liszt),
+    " | names: ", paste(head(names(liszt)), collapse = " "),
+    " ..."
+  )
   return(liszt)
 }
 


### PR DESCRIPTION
## Summary
- build history filenames without undefined `ppp()` and warn gracefully when history can't be saved
- replace undefined `kollapse()` with a simple message in `list.fromNames`

## Testing
- `R -q -e "source('R/CodeAndRoll2.R'); list.fromNames(c('A','B')); savehistory_2()"`
- `R CMD check --no-manual --no-build-vignettes .` *(fails: Required field missing or empty: 'Maintainer')*

------
https://chatgpt.com/codex/tasks/task_e_68931c88df60832cb9006508cc3a8b45