### PR TITLE
Fix cumsubtract default parameter

### DIFF
--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -1286,9 +1286,10 @@ MaxN <- function(vec = rpois(4, lambda = 3), topN = 2) {
 # _________________________________________________________________________________________________
 #' @title cumsubtract
 #' @description Cumulative subtraction, opposite of cumsum().
-#' @param numericVec PARAM_DESCRIPTION, Default: blanks
+#' @param numericVec Numeric vector to compute pairwise differences.
 #' @export
-cumsubtract <- function(numericVec = blanks) {
+cumsubtract <- function(numericVec) {
+  stopifnot(is.numeric(numericVec), length(numericVec) > 1)
   DiffZ <- numericVec[-1] - numericVec[-length(numericVec)]
   print(table(DiffZ))
   DiffZ

--- a/man/cumsubtract.Rd
+++ b/man/cumsubtract.Rd
@@ -4,10 +4,10 @@
 \alias{cumsubtract}
 \title{cumsubtract}
 \usage{
-cumsubtract(numericVec = blanks)
+cumsubtract(numericVec)
 }
 \arguments{
-\item{numericVec}{PARAM_DESCRIPTION, Default: blanks}
+\item{numericVec}{Numeric vector to compute pairwise differences.}
 }
 \description{
 Cumulative subtraction, opposite of cumsum().


### PR DESCRIPTION
## Summary
- fix `cumsubtract` so it requires a numeric vector and validates input
- update `cumsubtract` documentation accordingly

## Testing
- `R -q -e 'source("R/CodeAndRoll2.R"); cumsubtract(1:5)'` *(failed: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_6893214a8c80832c985a54bad3fff522