### PR TITLE
Fix package documentation and metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,9 @@
 Package: CodeAndRoll2
 Title: CodeAndRoll2 for vector, matrix and list manipulations
 Version: 2.7.0
-Authors@R: 
-    person("Abel", "Vertesy", , "av@imba.oeaw.ac.at", role = c("aut", "cre"))
-Author: Abel Vertesy <av@imba.oeaw.ac.at> [aut, cre]
+Author: Abel Vertesy [aut, cre]
 Maintainer: Abel Vertesy <av@imba.oeaw.ac.at>
-Description: CodeAndRoll2 is a set of more than 130 productivity
+Description: CodeAndRoll2 is a set of over 130 productivity
     functions for vector, matrix and list manipulations and math. Used by
     MarkdownReports, ggExpress, SeuratUtils, etc.
 License: GPL-3 + file LICENSE

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # CodeAndRoll2
 
-Packaged version of the core functionalities (vector, matrix and list manipulations; math) of the formerly used [CodeAndRoll (v1)](https://github.com/vertesy/CodeAndRoll).  A standalone set of more than 130 productivity functions.
+Packaged version of the core functionalities (vector, matrix and list manipulations; math) of the formerly used [CodeAndRoll (v1)](https://github.com/vertesy/CodeAndRoll). A standalone set of over 130 productivity functions.
 
 Used by [MarkdownReports](https://github.com/vertesy/MarkdownReports), [ggExpress](https://github.com/vertesy/ggExpress), [Seurat.utils](https://github.com/vertesy/Seurat.utils).
 
@@ -43,7 +43,7 @@ devtools::install_github(repo = "vertesy/CodeAndRoll2", upgrade = F)
 require("CodeAndRoll2")
 ```
 
-Alternatively, you simply source it from the web. 
+Alternatively, you can simply source it from the web.
 *This way function help will not work, and you will have no local copy of the code on your hard drive.*
 ```r
 source("https://raw.githubusercontent.com/vertesy/CodeAndRoll2/master/CodeAndRoll2/R/CodeAndRoll2.R")


### PR DESCRIPTION
## Summary
- clarify package description and remove redundant Author field
- fix README wording and grammar

## Testing
- `R CMD check .` *(fails: Packages required but not available: 'Stringendo', 'colorRamps', 'dplyr', 'gplots', 'gtools', 'plyr', 'purrr', 'RColorBrewer', 'rstudioapi', 'sessioninfo', 'stringr', 'tibble')*


------
https://chatgpt.com/codex/tasks/task_e_689326536f20832caf5935d721200021