### PR TITLE
Annotate code: explain the non-obvious operations

### DIFF
--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -963,6 +963,8 @@ as.named.vector.table <- function(table, verbose = TRUE,
   stopifnot("table must be 1D" = length(dim(table)) <= 1)
   stopifnot(HasNames(table))
 
+  # NOTE: BUG -- the lines that would actually build 'v' are commented out below,
+  # so 'v' is never defined; any call to this (deprecated) function errors.
   # v <- as.vector(unclass(table)); attributes(v) <- NULL; # Atomic vector with names
   # names(v) <- dimnames(table)[[1]]
   # Even after unclass(), the dim attribute remains, and is.vector() only returns TRUE if
@@ -1809,7 +1811,7 @@ pc_in_total_of_match <- function(vec_or_table, category, NA_omit = TRUE) {
         vec_or_table <- stats::na.omit(vec_or_table)
         iprint(sum(is.na(vec_or_table)), "NA are omitted from the vec_or_table of:", length(vec_or_table))
       }
-      "Not working completely: if NaN is stored as string, it does not detect it"
+      # NOTE: not working completely -- if NaN is stored as a string, it is not detected.
     }
 
     # Calculate the percentage
@@ -3647,6 +3649,9 @@ list.2.replicated.name.vec <- function(ListWithNames) {
 #'
 #' @export
 symdiff <- function(x, y, z = NULL) {
+  # A value that appears in 2+ of the (uniquified) input vectors shows up as a
+  # duplicate once they're all concatenated; removing those from each vector
+  # in turn leaves only what's unique to that one vector.
   big.vec <- c(unique(x), unique(y), unique(z))
   # ls <- list(x, y, z)
   ls <- Filter(function(l) !is.null(l), list(x, y, z))

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -14,4 +14,4 @@
 #'   if (!n) n <- stringr::str_count(string = string, pattern = pattern)
 #'   stringr::str_split_fixed(string, pattern = pattern, n = n)
 #'   }
-# "replace with str_split_1"
+# # TODO: replace with str_split_1


### PR DESCRIPTION
## Summary
This file was already well-commented from recent work, so only a few genuinely non-obvious spots needed annotation: the duplicate-removal trick in `symdiff()`. Normalized two stray bare-string "comments" into real `#`/`# TODO:` comments.

## Bugs found while reading (not fixed, just flagged with `# NOTE:` comments)
- `as.named.vector.table()` (deprecated): the lines that would actually build the return value `v` are commented out -- any call errors with "object 'v' not found".

Flagging for your call on whether/how to fix; didn't want to bundle a behavior change into a comments-only PR.
