### PR TITLE
fix: drop=FALSE to prevent crash when exactly 1 row is unique to one side

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CodeAndRoll2
 Title: CodeAndRoll2 for vector, matrix and list manipulations
-Version: 2.8.9
+Version: 2.8.13
 Authors@R: 
     person("Abel", "Vertesy", , "av@imba.oeaw.ac.at", role = c("aut", "cre"))
 Description: CodeAndRoll2 is a set of more than 170 productivity functions

--- a/Development/config.R
+++ b/Development/config.R
@@ -3,7 +3,7 @@
 
 DESCRIPTION <- list(
   package.name = "CodeAndRoll2",
-  version = "2.8.9",
+  version = "2.8.13",
   title = "CodeAndRoll2 for vector, matrix and list manipulations",
   description = "CodeAndRoll2 is a set of more than 170 productivity functions for vector, matrix
   and list manipulations and math. Used by MarkdownReports, ggExpress, SeuratUtils, etc.",

--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -2410,8 +2410,8 @@ combine.matrices.by.rowname.intersect <- function(matrix1, matrix2, k = 2) { # c
   merged <- cbind(matrix1[idx, ], matrix2[idx, ])
   diffz <- symdiff(rn1, rn2)
   print("Missing Rows 1, 2")
-  x1 <- rowSums(matrix1[diffz[[1]], ])
-  x2 <- rowSums(matrix2[diffz[[2]], ])
+  x1 <- rowSums(matrix1[diffz[[1]], , drop = FALSE])
+  x2 <- rowSums(matrix2[diffz[[2]], , drop = FALSE])
   print("")
   iprint("Values lost 1: ", round(sum(x1)), "or", Stringendo::percentage_formatter(sum(x1) / sum(merged)))
   print(tail(sort(x1), n = k))
@@ -2720,8 +2720,8 @@ merge_numeric_df_by_rn <- function(x, y) {
   merged[is.na(merged)] <- 0
 
   print("Uniq Rows (top 10 by sum)")
-  x1 <- rowSums(x[diffz[[1]], ])
-  x2 <- rowSums(y[diffz[[2]], ])
+  x1 <- rowSums(x[diffz[[1]], , drop = FALSE])
+  x2 <- rowSums(y[diffz[[2]], , drop = FALSE])
   print("")
   iprint("Values specific to 1: ", round(sum(x1)), "or", percentage_formatter(sum(x1) / sum(merged)))
   print(tail(sort(x1), n = 10))


### PR DESCRIPTION
### What was the bug?
`combine.matrices.by.rowname.intersect()` and `merge_numeric_df_by_rn()` share the same bug. After computing which row names are unique to each side (`diffz[[1]]`, `diffz[[2]]` from `symdiff()`), both do `rowSums(matrix1[diffz[[1]], ])` (or the data.frame equivalent) with the default `drop = TRUE`.

### What was the impact?
When exactly one row name is unique to a given side, single-row matrix/data.frame indexing collapses to a plain vector (R's default `drop = TRUE` behavior), and `rowSums()` on a non-array throws:
```
Error in rowSums(...) : 'x' must be an array of at least two dimensions
```
This isn't a contrived edge case — it's the ordinary shape of "two inputs that share all but one row name each," which is exactly the kind of input these row-merging functions are meant to handle.

### The fix
Added `drop = FALSE` to both subsetting operations in both functions (4 call sites total) — the identical fix for the identical root cause, applied identically.

### Testing
```r
# combine.matrices.by.rowname.intersect: 4 rows each, sharing 3, 1 unique per side
m1 <- matrix(1:8, nrow=4, dimnames=list(c("a","b","c","d"), c("x","y")))
m2 <- matrix(9:16, nrow=4, dimnames=list(c("b","c","d","e"), c("x","y")))
combine.matrices.by.rowname.intersect(m1, m2)

# merge_numeric_df_by_rn: same row-name pattern, data.frame inputs
df1 <- data.frame(v1 = c(1,2,3,4), row.names = c("a","b","c","d"))
df2 <- data.frame(v2 = c(9,10,11,12), row.names = c("b","c","d","e"))
merge_numeric_df_by_rn(df1, df2)
```
Before: both calls errored with `'x' must be an array of at least two dimensions`.
After: both complete successfully — the first returns the correctly merged 3x4 matrix, the second the correctly merged 5x2 data frame. Both functions' normal multi-row-difference behavior is unaffected (`drop = FALSE` is a no-op when more than one row is selected).

- `R CMD build` + `R CMD check`: no new NOTEs/WARNINGs/ERRORs vs. the current `dev` branch (the one remaining ERROR, a missing `@export` on `pU()`, is pre-existing and already tracked separately).
- No `.Rd`/`NAMESPACE` change needed (roxygen blocks unchanged).
- No `testthat`/automated tests added, per repo convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCX65S6W8LjGL39WtG6Eiu)_