### PR TITLE
fix: remove.na.rows() ignored the cols subset and crashed on single column

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CodeAndRoll2
 Title: CodeAndRoll2 for vector, matrix and list manipulations
-Version: 2.8.9
+Version: 2.8.14
 Authors@R: 
     person("Abel", "Vertesy", , "av@imba.oeaw.ac.at", role = c("aut", "cre"))
 Description: CodeAndRoll2 is a set of more than 170 productivity functions

--- a/Development/config.R
+++ b/Development/config.R
@@ -3,7 +3,7 @@
 
 DESCRIPTION <- list(
   package.name = "CodeAndRoll2",
-  version = "2.8.9",
+  version = "2.8.14",
   title = "CodeAndRoll2 for vector, matrix and list manipulations",
   description = "CodeAndRoll2 is a set of more than 170 productivity functions for vector, matrix
   and list manipulations and math. Used by MarkdownReports, ggExpress, SeuratUtils, etc.",

--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -2935,8 +2935,8 @@ na.omit.mat <- function(mat, any = TRUE) {
 #' @param cols Cols to check for NAs, Default: 1:NCOL(mat)
 #' @export
 remove.na.rows <- function(mat, cols = 1:NCOL(mat)) {
-  mat2 <- mat[, cols]
-  idxOK <- which(rowSums(!apply(mat2, 2, is.na)) == NCOL(mat))
+  mat2 <- mat[, cols, drop = FALSE]
+  idxOK <- which(rowSums(!apply(mat2, 2, is.na)) == NCOL(mat2))
   mat[idxOK, ]
 }
 

--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -2936,7 +2936,7 @@ na.omit.mat <- function(mat, any = TRUE) {
 #' @export
 remove.na.rows <- function(mat, cols = 1:NCOL(mat)) {
   mat2 <- mat[, cols, drop = FALSE]
-  idxOK <- which(rowSums(!apply(mat2, 2, is.na)) == NCOL(mat2))
+  idxOK <- which(rowSums(!is.na(mat2)) == NCOL(mat2))
   mat[idxOK, ]
 }
 


### PR DESCRIPTION
### What was the bug?
Two bugs in one function:

1. **Wrong completeness check.** The check compared the per-row non-NA count in the *selected `cols` subset* against `NCOL(mat)` — the *full* matrix's column count:
   ```r
   idxOK <- which(rowSums(!apply(mat2, 2, is.na)) == NCOL(mat))
   ```
   Whenever `cols` was a proper subset of all columns (exactly what the `cols` parameter is documented for: "Cols to check for NAs"), a row's per-checked-column non-NA count can never reach the *full* matrix's column count unless `cols` happens to be every column. Net effect: passing any `cols` narrower than the whole matrix silently dropped rows based on NAs **outside** the columns the caller asked to check — or dropped every row entirely.

2. **Crash on a single-column subset.** `mat[, cols]` used the default `drop = TRUE`, so `cols = 2` (a single column) collapsed to a plain vector, and `apply(mat2, 2, is.na)` on a vector throws `dim(X) must have a positive length`.

### The fix
- Added `drop = FALSE` to the subsetting.
- Compare against `NCOL(mat2)` (the actual subset size) instead of `NCOL(mat)`.

### Testing
4x3 matrix, one NA in column `a` (row `r3`), one NA in column `b` (row `r2`):
```r
remove.na.rows(mat)                # default, all columns
remove.na.rows(mat, cols = c(1,3)) # columns a,c only
remove.na.rows(mat, cols = 1)      # column a only
remove.na.rows(mat, cols = 2)      # column b only
```
- Default: drops `r2`, `r3`, keeps `r1`/`r4` — unchanged.
- `cols = c(1,3)`: now correctly keeps `r2` (its only NA is in column `b`, not checked) — previously this dropped every row, including ones with zero NAs anywhere in the checked columns.
- `cols = 1`: previously crashed; now correctly drops only `r3`.
- `cols = 2`: previously crashed; now correctly drops only `r2`.

- `R CMD build` + `R CMD check`: no new NOTEs/WARNINGs/ERRORs vs. the current `dev` branch (the one remaining ERROR, a missing `@export` on `pU()`, is pre-existing and already tracked separately).
- No `.Rd`/`NAMESPACE` change needed (roxygen block unchanged).
- No `testthat`/automated tests added, per repo convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCX65S6W8LjGL39WtG6Eiu)_