### PR TITLE
Fix as.named.vector.table() undefined-variable crash

### DIFF
--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -963,10 +963,11 @@ as.named.vector.table <- function(table, verbose = TRUE,
   stopifnot("table must be 1D" = length(dim(table)) <= 1)
   stopifnot(Stringendo::HasNames(table))
 
-  # v <- as.vector(unclass(table)); attributes(v) <- NULL; # Atomic vector with names
-  # names(v) <- dimnames(table)[[1]]
   # Even after unclass(), the dim attribute remains, and is.vector() only returns TRUE if
   # an object has no attributes other than names.
+  v <- as.vector(unclass(table))
+  attributes(v) <- NULL
+  names(v) <- dimnames(table)[[1]]
 
   stopifnot(length(v) == length(table))
   return(v)


### PR DESCRIPTION
## Summary
Fixes the 1 bug flagged during the recent code-annotation pass ([#62](https://github.com/vertesy/CodeAndRoll2/pull/62)), in `R/CodeAndRoll2.R`.

## Why
`as.named.vector.table()` (deprecated in favor of `c()`) never actually built its return value `v` — the lines that construct it were commented out, so every call errored with "object 'v' not found". Restored the commented-out build logic.

Verified interactively via `devtools::load_all()`; no `tests/` directory exists in this repo to run.