### PR TITLE
Fix broken \link{} in movingAve2()/imovingSEM() @title tags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CodeAndRoll2
 Title: CodeAndRoll2 for vector, matrix and list manipulations
-Version: 2.8.15
+Version: 2.8.16
 Authors@R: 
     person("Abel", "Vertesy", , "av@imba.oeaw.ac.at", role = c("aut", "cre"))
 Description: CodeAndRoll2 is a set of more than 170 productivity functions

--- a/Development/config.R
+++ b/Development/config.R
@@ -3,7 +3,7 @@
 
 DESCRIPTION <- list(
   package.name = "CodeAndRoll2",
-  version = "2.8.15",
+  version = "2.8.16",
   title = "CodeAndRoll2 for vector, matrix and list manipulations",
   description = "CodeAndRoll2 is a set of more than 170 productivity functions for vector, matrix
   and list manipulations and math. Used by MarkdownReports, ggExpress, SeuratUtils, etc.",

--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -3927,7 +3927,7 @@ movingAve <- function(x, oneSide = 5, partial = TRUE) {
 
 
 # _________________________________________________________________________________________________
-#' @title Moving / rolling average (v2, filter) [Deprecated]
+#' @title Moving / rolling average (v2, filter) (Deprecated)
 #' @description Calculates the moving / rolling average of a numeric vector, using `filter()`.
 #' Deprecated in favor of [movingAve()], which offers the same shrinking- vs. fixed-window
 #' choice (via `partial`) in a single implementation. Note `n` here is the *total* window
@@ -3981,7 +3981,7 @@ movingSEM <- function(x, oneSide = 5, partial = TRUE) {
 
 
 # _________________________________________________________________________________________________
-#' @title imovingSEM [Deprecated]
+#' @title imovingSEM (Deprecated)
 #'
 #' @description Calculates the moving / rolling standard error of the mean (SEM), shrinking the
 #' window near the edges. Deprecated: identical to `movingSEM(x, oneSide, partial = TRUE)`, use

--- a/man/imovingSEM.Rd
+++ b/man/imovingSEM.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/CodeAndRoll2.R
 \name{imovingSEM}
 \alias{imovingSEM}
-\title{imovingSEM [Deprecated]}
+\title{imovingSEM (Deprecated)}
 \usage{
 imovingSEM(x, oneSide = 5)
 }

--- a/man/movingAve2.Rd
+++ b/man/movingAve2.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/CodeAndRoll2.R
 \name{movingAve2}
 \alias{movingAve2}
-\title{Moving / rolling average (v2, filter) [Deprecated]}
+\title{Moving / rolling average (v2, filter) (Deprecated)}
 \usage{
 movingAve2(x, n = 5)
 }


### PR DESCRIPTION
## What

The just-merged PR #65 added `@title ... [Deprecated]` to `movingAve2()` and `imovingSEM()`. With `Roxygen: list(markdown = TRUE)` (this package's setting), roxygen2's markdown parser reads a bare `[Deprecated]` as a markdown reference-style link and silently converts it to `\link{Deprecated}` in the generated `.Rd` file — a broken link, since no help topic named "Deprecated" exists anywhere in this package.

Confirmed by regenerating docs with `roxygen2::roxygenise()` from the current source and diffing against the checked-in `.Rd` files — before this fix, regeneration produces exactly this broken `\link{Deprecated}` in both `man/movingAve2.Rd` and `man/imovingSEM.Rd`.

## Fix

Changed both `@title` tags to use parentheses, `(Deprecated)`, instead of square brackets. Regenerated `man/movingAve2.Rd` and `man/imovingSEM.Rd` and confirmed the `\link{}` is gone and the rest of both files is unchanged; `NAMESPACE` needed no change.

## Verification

- `R CMD build .` succeeds.
- Regenerated docs via `roxygen2::roxygenise()` and diffed: only the intended `[Deprecated]` → `(Deprecated)` change in the two `.Rd` files, nothing else.
- `R CMD check`'s dependency-availability step cannot complete in this sandbox: `ReadWriter` (a recently added hard `Imports`) pulls in `qs`, which has a compile-time incompatibility with the `stringfish` version buildable here. This is a pre-existing environment limitation, unrelated to this change (confirmed it also blocks a clean check on unmodified `dev`). Relied on direct `R CMD build` + roxygen2 regeneration/diffing instead.
- Version bumped `2.8.15` → `2.8.16` in `Development/config.R`/`DESCRIPTION` per repo convention.

Small, mechanical, docs-only fix — no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCX65S6W8LjGL39WtG6Eiu)_