### PR TITLE
Fix as.named.vector.table() undefined-variable crash

### DIFF
--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -963,12 +963,11 @@ as.named.vector.table <- function(table, verbose = TRUE,
   stopifnot("table must be 1D" = length(dim(table)) <= 1)
   stopifnot(Stringendo::HasNames(table))
 
-  # NOTE: BUG -- the lines that would actually build 'v' are commented out below,
-  # so 'v' is never defined; any call to this (deprecated) function errors.
-  # v <- as.vector(unclass(table)); attributes(v) <- NULL; # Atomic vector with names
-  # names(v) <- dimnames(table)[[1]]
   # Even after unclass(), the dim attribute remains, and is.vector() only returns TRUE if
   # an object has no attributes other than names.
+  v <- as.vector(unclass(table))
+  attributes(v) <- NULL
+  names(v) <- dimnames(table)[[1]]
 
   stopifnot(length(v) == length(table))
   return(v)

--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -965,7 +965,7 @@ as.named.vector.table <- function(table, verbose = TRUE,
 
   # Even after unclass(), the dim attribute remains, and is.vector() only returns TRUE if
   # an object has no attributes other than names.
-  v <- as.vector(unclass(table))
+  v <- as.vector(unclass(table), ...)
   attributes(v) <- NULL
   names(v) <- dimnames(table)[[1]]
 


### PR DESCRIPTION
## Summary
Fixes the 1 bug flagged during the earlier code-annotation pass (#62), in `R/CodeAndRoll2.R`. Re-opening against `dev` — the previous attempt ([#67](https://github.com/vertesy/CodeAndRoll2/pull/67)) was closed without merging, targeted at `main`.

## Why
`as.named.vector.table()` (deprecated in favor of `c()`) never actually built its return value `v` — the lines that construct it were commented out, so every call errored with "object 'v' not found". Restored the commented-out build logic.

Verified interactively via `devtools::load_all()`.