### PR TITLE
Fix select_rows_and_columns() silently returning a vector for single row/column selections

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CodeAndRoll2
 Title: CodeAndRoll2 for vector, matrix and list manipulations
-Version: 2.8.16
+Version: 2.8.19
 Authors@R: 
     person("Abel", "Vertesy", , "av@imba.oeaw.ac.at", role = c("aut", "cre"))
 Description: CodeAndRoll2 is a set of more than 170 productivity functions

--- a/Development/config.R
+++ b/Development/config.R
@@ -3,7 +3,7 @@
 
 DESCRIPTION <- list(
   package.name = "CodeAndRoll2",
-  version = "2.8.16",
+  version = "2.8.19",
   title = "CodeAndRoll2 for vector, matrix and list manipulations",
   description = "CodeAndRoll2 is a set of more than 170 productivity functions for vector, matrix
   and list manipulations and math. Used by MarkdownReports, ggExpress, SeuratUtils, etc.",

--- a/R/CodeAndRoll2.R
+++ b/R/CodeAndRoll2.R
@@ -2547,7 +2547,7 @@ select_rows_and_columns <- function(df, RowIDs = NULL, ColIDs = NULL) {
     } else {
       Stringendo::iprint("All row IDs found")
     } # if
-    df <- df[true_rownames, ]
+    df <- df[true_rownames, , drop = FALSE]
   } # if
   if (length(ColIDs)) {
     true_colnames <- intersect(colnames(df), ColIDs)
@@ -2557,7 +2557,7 @@ select_rows_and_columns <- function(df, RowIDs = NULL, ColIDs = NULL) {
     } else {
       Stringendo::iprint("All column IDs found")
     }
-    df <- df[, true_colnames]
+    df <- df[, true_colnames, drop = FALSE]
   } # if
   Stringendo::iprint(dim(df))
   return(df)


### PR DESCRIPTION
## The bug

Both subset operations, `df[true_rownames, ]` and `df[, true_colnames]`, were missing `drop = FALSE`. Base R's default `drop = TRUE` collapses a data.frame subset to a plain vector whenever exactly one row or one column is selected, silently changing the return type from data.frame to vector for any caller who requests a single `RowID` or `ColID`. This also broke the function's own trailing `Stringendo::iprint(dim(df))` diagnostic, which prints `NULL` for a vector instead of the actual dimensions.

## Fix

Add `drop = FALSE` to both subset operations, matching the same fix already applied to other functions in this file (`combine.matrices.by.rowname.intersect`, `merge_numeric_df_by_rn`).

## Verification

- Selecting a single column (`ColIDs = "a"`) and a single row (`RowIDs = "r1"`) now both correctly return a data.frame with the expected `dim()` printed, instead of silently degrading to a vector.
- The normal multi-row/multi-col case is unaffected (verified with `RowIDs = c("r1","r2"), ColIDs = c("a","b")`).
- `R CMD build .` succeeds.
- Version bumped `2.8.16` → `2.8.19` (distinct from sibling PRs #75/#76, which also branch from the same `2.8.16` base and already claimed `2.8.17`/`2.8.18`).
- `R CMD check`'s dependency-availability step cannot complete in this sandbox due to a pre-existing, unrelated environment limitation (`ReadWriter`'s dependency `qs` fails to compile against the available `stringfish` version here) — same issue already documented on PR #71/#75/#76, confirmed unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCX65S6W8LjGL39WtG6Eiu)_